### PR TITLE
Hotfix/unity5

### DIFF
--- a/Assets/MaterialUI/Editor/MaterialUIEditorTools.cs
+++ b/Assets/MaterialUI/Editor/MaterialUIEditorTools.cs
@@ -261,7 +261,7 @@ public static class MaterialUIEditorTools
 		{
 			if (GameObject.Find(selectedObject.name))
 			{
-				selectedObject.AddComponent("RippleConfig");
+				selectedObject.AddComponent<RippleConfig>();
 			}
 		}
 	}
@@ -276,7 +276,7 @@ public static class MaterialUIEditorTools
 		{
 			if (GameObject.Find(selectedObject.name))
 			{
-				selectedObject.AddComponent("ShadowConfig");
+				selectedObject.AddComponent<ShadowConfig>();
 			}
 		}
 	}
@@ -291,7 +291,7 @@ public static class MaterialUIEditorTools
 		{
 			if (GameObject.Find(selectedObject.name))
 			{
-				selectedObject.AddComponent("RectTransformSnap");
+				selectedObject.AddComponent<RectTransformSnap>();
 			}
 		}
 	}
@@ -306,7 +306,7 @@ public static class MaterialUIEditorTools
 		{
 			if (GameObject.Find(selectedObject.name))
 			{
-				selectedObject.AddComponent("ShadowGen");
+				selectedObject.AddComponent<ShadowGen>();
 			}
 		}
 	}
@@ -321,7 +321,7 @@ public static class MaterialUIEditorTools
 		{
 			if (GameObject.Find(selectedObject.name))
 			{
-				selectedObject.AddComponent("Toaster");
+				selectedObject.AddComponent<Toaster>();
 			}
 		}
 	}
@@ -336,7 +336,7 @@ public static class MaterialUIEditorTools
 		{
 			if (GameObject.Find(selectedObject.name))
 			{
-				selectedObject.AddComponent("EZAnim");
+				selectedObject.AddComponent<EZAnim>();
 			}
 		}
 	}

--- a/Assets/MaterialUI/Scripts/FPSCounter.cs
+++ b/Assets/MaterialUI/Scripts/FPSCounter.cs
@@ -42,7 +42,7 @@ namespace MaterialUI
 				theText.text = "" + (accum/frames).ToString("f2") + " FPS";
 				if ((accum/frames) < 1)
 				{
-					guiText.text = "";
+					theText.text = "";
 				}
 				timeleft = updateInterval;
 				accum = 0f;

--- a/Assets/MaterialUI/Scripts/SnapButtonToText.cs
+++ b/Assets/MaterialUI/Scripts/SnapButtonToText.cs
@@ -47,13 +47,13 @@ public class SnapButtonToText : MonoBehaviour
 
 	IEnumerator SnapEnum()
 	{
-		layoutGroup = buttonLayerRect.gameObject.AddComponent("HorizontalLayoutGroup") as HorizontalLayoutGroup;
+		layoutGroup = buttonLayerRect.gameObject.AddComponent<HorizontalLayoutGroup>() as HorizontalLayoutGroup;
 		layoutGroup.padding = new RectOffset (16, 16, 9, 7);
 		layoutGroup.childAlignment = TextAnchor.MiddleCenter;
 		layoutGroup.childForceExpandWidth = true;
 		layoutGroup.childForceExpandHeight = true;
 
-		sizeFitter = buttonLayerRect.gameObject.AddComponent ("ContentSizeFitter") as ContentSizeFitter;
+		sizeFitter = buttonLayerRect.gameObject.AddComponent<ContentSizeFitter>() as ContentSizeFitter;
 		sizeFitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
 		sizeFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
 


### PR DESCRIPTION
Hello!

Just some small compilation errors fixed when using Unity5. You can merge them directly in your project if you want, it will also work on Unity 4.6 of course :)

Also, I didn't send a pull request for this because it mess up with the file diffs for one simple thing, but there are multiple classes that do not have the namespace MaterialUI, and it's causing compilation error on Unity5 too:
- MaterialUIEditorTools
- SnapButtonToTextEditor
- ColorCopier
- HSBColor
- MaterialUIScaler
- RectTransformSnap
- SnapButtonToText

Thanks for this awesome project!