### PR TITLE
Fixed NavDrawer not using the correct position.

### DIFF
--- a/Scripts/NavDrawerConfig.cs
+++ b/Scripts/NavDrawerConfig.cs
@@ -133,10 +133,10 @@ namespace MaterialUI
 
 		public void OnDrag(PointerEventData data)
 		{
-			tempVector2 = thisRectTransform.position;
+			tempVector2 = thisRectTransform.anchoredPosition;
 			tempVector2.x += data.delta.x;
 
-			thisRectTransform.position = tempVector2;
+			thisRectTransform.anchoredPosition = tempVector2;
 
 			backgroundCanvasGroup.alpha = 1 - (maxPosition - thisRectTransform.anchoredPosition.x) / (maxPosition - minPosition);
 			shadowCanvasGroup.alpha = 1 - (maxPosition - thisRectTransform.anchoredPosition.x) / ((maxPosition - minPosition) * 2);


### PR DESCRIPTION
This was breaking the dragging function and was setting the Z position to 0 when dragged because of a conversion from Vector2 to Vector3 (making the Z=0)